### PR TITLE
Add configurable timeouts to provider config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -106,4 +106,6 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
 * `retrywrites   ` - (Optional) `default = true `Retryable writes allow MongoDB drivers to automatically retry certain write operations a single time if they encounter network errors, or if they cannot find a healthy primary in the replica sets or sharded cluster.
 * `direct   ` - (Optional) `default = false ` determine if a direct connection is needed..
 * `proxy   ` - (Optional) `default = "" ` determine if connecting via a SOCKS5 proxy is needed, it can also be sourced from the `ALL_PROXY` or `all_proxy` environment variable.
-
+* `timeout` - (Optional) `default = 10000 ` Specifies the number of milliseconds that a single operation run on the Client can take before returning a timeout error.
+* `connect_timeout` - (Optional) `default = 30000 ` Specifies the time in milliseconds to attempt a connection before timing out.
+* `server_selection_timeout` - (Optional) Specifies the time in milliseconds to wait to find an available, suitable server to execute an operation.

--- a/mongodb/resource_db_role.go
+++ b/mongodb/resource_db_role.go
@@ -80,7 +80,7 @@ func resourceDatabaseRole() *schema.Resource {
 }
 
 func resourceDatabaseRoleCreate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*MongoDatabaseConfiguration)
+	var config = i.(*ClientConfig)
 	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
@@ -114,7 +114,7 @@ func resourceDatabaseRoleCreate(ctx context.Context, data *schema.ResourceData, 
 }
 
 func resourceDatabaseRoleDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*MongoDatabaseConfiguration)
+	var config = i.(*ClientConfig)
 	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
@@ -137,7 +137,7 @@ func resourceDatabaseRoleDelete(ctx context.Context, data *schema.ResourceData, 
 }
 
 func resourceDatabaseRoleUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*MongoDatabaseConfiguration)
+	var config = i.(*ClientConfig)
 	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
@@ -179,7 +179,7 @@ func resourceDatabaseRoleUpdate(ctx context.Context, data *schema.ResourceData, 
 
 func resourceDatabaseRoleRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	var config = i.(*MongoDatabaseConfiguration)
+	var config = i.(*ClientConfig)
 	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
-	"strings"
 )
 
 func resourceDatabaseUser() *schema.Resource {
@@ -25,11 +26,11 @@ func resourceDatabaseUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"name":{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"password":{
+			"password": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -54,11 +55,9 @@ func resourceDatabaseUser() *schema.Resource {
 	}
 }
 
-
-
 func resourceDatabaseUserDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*MongoDatabaseConfiguration)
-	client , connectionError := MongoClientInit(config)
+	var config = i.(*ClientConfig)
+	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
 	}
@@ -78,15 +77,15 @@ func resourceDatabaseUserDelete(ctx context.Context, data *schema.ResourceData, 
 
 	result := adminDB.RunCommand(context.Background(), bson.D{{Key: "dropUser", Value: userName}})
 	if result.Err() != nil {
-		return diag.Errorf("%s",result.Err())
+		return diag.Errorf("%s", result.Err())
 	}
 
 	return nil
 }
 
 func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*MongoDatabaseConfiguration)
-	client , connectionError := MongoClientInit(config)
+	var config = i.(*ClientConfig)
+	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
 	}
@@ -99,12 +98,12 @@ func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, 
 	var userName = data.Get("name").(string)
 	var database = data.Get("auth_database").(string)
 	var userPassword = data.Get("password").(string)
-	
+
 	adminDB := client.Database(database)
 
 	result := adminDB.RunCommand(context.Background(), bson.D{{Key: "dropUser", Value: userName}})
 	if result.Err() != nil {
-		return diag.Errorf("%s",result.Err())
+		return diag.Errorf("%s", result.Err())
 	}
 	var roleList []Role
 	var user = DbUser{
@@ -116,29 +115,29 @@ func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, 
 	if roleMapErr != nil {
 		return diag.Errorf("Error decoding map : %s ", roleMapErr)
 	}
-	err2 := createUser(client,user,roleList,database)
+	err2 := createUser(client, user, roleList, database)
 	if err2 != nil {
 		return diag.Errorf("Could not create the user : %s ", err2)
 	}
 
-	newId := database+"."+userName
+	newId := database + "." + userName
 	encoded := base64.StdEncoding.EncodeToString([]byte(newId))
 	data.SetId(encoded)
 	return resourceDatabaseUserRead(ctx, data, i)
 }
 
 func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*MongoDatabaseConfiguration)
-	client , connectionError := MongoClientInit(config)
+	var config = i.(*ClientConfig)
+	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
 	}
 	stateID := data.State().ID
-	username, database , err := resourceDatabaseUserParseId(stateID)
+	username, database, err := resourceDatabaseUserParseId(stateID)
 	if err != nil {
-		return diag.Errorf("%s",err)
+		return diag.Errorf("%s", err)
 	}
-	result , decodeError := getUser(client,username,database)
+	result, decodeError := getUser(client, username, database)
 	if decodeError != nil {
 		return diag.Errorf("Error decoding user : %s ", err)
 	}
@@ -148,30 +147,30 @@ func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i 
 	roles := make([]interface{}, len(result.Users[0].Roles))
 
 	for i, s := range result.Users[0].Roles {
-			roles[i] = map[string]interface{}{
-				"db": s.Db,
-				"role": s.Role,
-			}
+		roles[i] = map[string]interface{}{
+			"db":   s.Db,
+			"role": s.Role,
+		}
 	}
 	dataSetError := data.Set("role", roles)
-	if dataSetError != nil  {
-		return diag.Errorf("error setting role : %s " , dataSetError)
+	if dataSetError != nil {
+		return diag.Errorf("error setting role : %s ", dataSetError)
 	}
 	dataSetError = data.Set("auth_database", database)
-	if dataSetError != nil  {
-		return diag.Errorf("error setting auth_db : %s " , dataSetError)
+	if dataSetError != nil {
+		return diag.Errorf("error setting auth_db : %s ", dataSetError)
 	}
 	dataSetError = data.Set("password", data.Get("password"))
-	if dataSetError != nil  {
-		return diag.Errorf("error setting password : %s " , dataSetError)
+	if dataSetError != nil {
+		return diag.Errorf("error setting password : %s ", dataSetError)
 	}
 	data.SetId(stateID)
 	return nil
 }
 
 func resourceDatabaseUserCreate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*MongoDatabaseConfiguration)
-	client , connectionError := MongoClientInit(config)
+	var config = i.(*ClientConfig)
+	client, connectionError := MongoClientInit(config)
 	if connectionError != nil {
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
 	}
@@ -188,18 +187,18 @@ func resourceDatabaseUserCreate(ctx context.Context, data *schema.ResourceData, 
 	if roleMapErr != nil {
 		return diag.Errorf("Error decoding map : %s ", roleMapErr)
 	}
-	err := createUser(client,user,roleList,database)
+	err := createUser(client, user, roleList, database)
 	if err != nil {
 		return diag.Errorf("Could not create the user : %s ", err)
 	}
-	str := database+"."+userName
+	str := database + "." + userName
 	encoded := base64.StdEncoding.EncodeToString([]byte(str))
 	data.SetId(encoded)
 	return resourceDatabaseUserRead(ctx, data, i)
 }
 
-func resourceDatabaseUserParseId(id string) (string, string, error){
-	result , errEncoding := base64.StdEncoding.DecodeString(id)
+func resourceDatabaseUserParseId(id string) (string, string, error) {
+	result, errEncoding := base64.StdEncoding.DecodeString(id)
 
 	if errEncoding != nil {
 		return "", "", fmt.Errorf("unexpected format of ID Error : %s", errEncoding)
@@ -212,5 +211,5 @@ func resourceDatabaseUserParseId(id string) (string, string, error){
 	database := parts[0]
 	userName := parts[1]
 
-	return userName , database , nil
+	return userName, database, nil
 }


### PR DESCRIPTION
We are having issues when Mongo is busy, or there is a large number of managed resources by the Terraform provider with timeouts, especially when running from GH runners in a different part of the world. This PR adds optional timeouts to the provider config for different MongoDB Driver timeout settings. 

Also `go fmt` linting changes