### PR TITLE
Fix inability to delete users with dots

### DIFF
--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -69,8 +69,8 @@ func resourceDatabaseUserDelete(ctx context.Context, data *schema.ResourceData, 
 		return diag.Errorf("ID mismatch %s", errEncoding)
 	}
 
-	// StateID is a concatenation of database and username. We only use the username here.
-	splitId := strings.Split(string(id), ".")
+	// StateID is a concatenation of database and username (database.user.name). We only use the username here.
+	splitId := strings.SplitN(string(id), ".", 2)
 	userName := splitId[1]
 
 	adminDB := client.Database(database)


### PR DESCRIPTION
Otherwise, this results in an error for user `foo.bar`:
```
Error: (UserNotFound) User 'foo@admin' not found
```

Also, why do we use `Id` here at all? We could also use `data.State().Name` and be done with it.