### PR TITLE
configure authentication mechanism

### DIFF
--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -34,8 +34,9 @@ type ClientConfig struct {
 	ServerSelectionTimeout int
 }
 type DbUser struct {
-	Name     string `json:"name"`
-	Password string `json:"password"`
+	Name        string `json:"name"`
+	Password    string `json:"password"`
+	Mechanisms  []string `json:"mechanisms"`
 }
 
 type Role struct {
@@ -62,6 +63,7 @@ type SingleResultGetUser struct {
 		Id    string `json:"_id"`
 		User  string `json:"user"`
 		Db    string `json:"db"`
+		Mechanisms    []string `json:"mechanisms"`
 		Roles []struct {
 			Role string `json:"role"`
 			Db   string `json:"db"`
@@ -190,13 +192,20 @@ func (resource Resource) String() string {
 
 func createUser(client *mongo.Client, user DbUser, roles []Role, database string) error {
 	var result *mongo.SingleResult
-	if len(roles) != 0 {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createUser", Value: user.Name},
-			{Key: "pwd", Value: user.Password}, {Key: "roles", Value: roles}})
-	} else {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createUser", Value: user.Name},
-			{Key: "pwd", Value: user.Password}, {Key: "roles", Value: []bson.M{}}})
+	var args = bson.D{}
+	args = append(args, bson.E{Key: "createUser", Value: user.Name})
+	if user.Password != "" {
+	    args = append(args, bson.E{Key: "pwd", Value: user.Password})
 	}
+    if user.Mechanisms != nil {
+	    args = append(args, bson.E{Key: "mechanisms", Value: user.Mechanisms})
+	}
+    if len(roles) != 0 {
+	    args = append(args, bson.E{Key: "roles", Value: roles})
+	} else {
+	    args = append(args, bson.E{Key: "roles", Value: []bson.M{}})
+	}
+    result = client.Database(database).RunCommand(context.Background(), args)
 
 	if result.Err() != nil {
 		return result.Err()

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -197,7 +197,7 @@ func createUser(client *mongo.Client, user DbUser, roles []Role, database string
 	if user.Password != "" {
 	    args = append(args, bson.E{Key: "pwd", Value: user.Password})
 	}
-    if user.Mechanisms != nil {
+    if len(user.Mechanisms) != 0 {
 	    args = append(args, bson.E{Key: "mechanisms", Value: user.Mechanisms})
 	}
     if len(roles) != 0 {

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -32,8 +32,16 @@ func resourceDatabaseUser() *schema.Resource {
 			},
 			"password": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
+            "mechanisms": {
+                Type:     schema.TypeSet,
+                Optional: true,
+                MaxItems: 10,
+                Elem: &schema.Schema{
+                    Type:     schema.TypeString,
+                },
+            },
 			"role": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -98,6 +106,7 @@ func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, 
 	var userName = data.Get("name").(string)
 	var database = data.Get("auth_database").(string)
 	var userPassword = data.Get("password").(string)
+	var mechanisms = data.Get("mechanisms").(*schema.Set).List()
 
 	adminDB := client.Database(database)
 
@@ -106,9 +115,15 @@ func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, 
 		return diag.Errorf("%s", result.Err())
 	}
 	var roleList []Role
+	var mechanismsList []string
+	mechanismsMapErr := mapstructure.Decode(mechanisms, &mechanismsList)
+    if mechanismsMapErr != nil {
+        return diag.Errorf("Error decoding map : %s ", mechanismsMapErr)
+    }
 	var user = DbUser{
 		Name:     userName,
 		Password: userPassword,
+		Mechanisms: mechanismsList,
 	}
 	roles := data.Get("role").(*schema.Set).List()
 	roleMapErr := mapstructure.Decode(roles, &roleList)
@@ -138,6 +153,7 @@ func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i 
 		return diag.Errorf("%s", err)
 	}
 	result, decodeError := getUser(client, username, database)
+	    diag.Errorf("found user: %s", result)
 	if decodeError != nil {
 		return diag.Errorf("Error decoding user : %s ", err)
 	}
@@ -177,10 +193,17 @@ func resourceDatabaseUserCreate(ctx context.Context, data *schema.ResourceData, 
 	var database = data.Get("auth_database").(string)
 	var userName = data.Get("name").(string)
 	var userPassword = data.Get("password").(string)
+	var mechanisms = data.Get("mechanisms").(*schema.Set).List()
 	var roleList []Role
+    var mechanismsList []string
+    mechanismsMapErr := mapstructure.Decode(mechanisms, &mechanismsList)
+    if mechanismsMapErr != nil {
+        return diag.Errorf("Error decoding map : %s ", mechanismsMapErr)
+    }
 	var user = DbUser{
 		Name:     userName,
 		Password: userPassword,
+		Mechanisms: mechanismsList,
 	}
 	roles := data.Get("role").(*schema.Set).List()
 	roleMapErr := mapstructure.Decode(roles, &roleList)


### PR DESCRIPTION
In the current state, this provider only allows to create users with username/password credentials. In our setup, we want to provision users on AWS DocumentDB, which authenticate using AWS IAM (https://docs.aws.amazon.com/documentdb/latest/developerguide/iam-identity-auth.html).

For this to work, I extended this provider to be able to configure the authentication mechanisms. Also the password is now optional.