### PR TITLE
Optimize and simplify the MongoDB client usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ TERRAFORM_PLUGINS_DIRECTORY=~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NA
 install:
 	mkdir -p ${TERRAFORM_PLUGINS_DIRECTORY}
 	go build -o ${TERRAFORM_PLUGINS_DIRECTORY}/terraform-provider-${NAME}
-	cd examples && rm -rf .terraform
+	cd examples && rm -rf .terraform*
 	cd examples && make init
 re-install:
 	rm -f ${TERRAFORM_PLUGINS_DIRECTORY}/terraform-provider-${NAME}
 	go build -o ${TERRAFORM_PLUGINS_DIRECTORY}/terraform-provider-${NAME}
-	cd examples && rm -rf .terraform
+	cd examples && rm -rf .terraform*
 	cd examples && make init
 lint:
 	 golangci-lint run

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
-
 # MongoDB Provider
 
 The MongoDB provider is used to interact with the resources supported by [MongoDB](https://www.mongodb.com/). The provider needs to be configured with the proper credentials before it can be used.
@@ -22,7 +21,6 @@ provider "mongodb" {
   retrywrites = false # default true
   direct = true // default false
   proxy = "socks5://myproxy:8080" // Optional
-  
 }
 ```
 
@@ -31,12 +29,9 @@ provider "mongodb" {
 ```hcl
 # Configure the MongoDB Provider
 provider "mongodb" {
-
-  insecure_skip_verify = true  # default false (set to true to ignore hostname verification) 
+  insecure_skip_verify = true  # default false (set to true to ignore hostname verification)
   # -> specify certificate path
   certificate = file(pathexpand("path/to/certificate/ca.pem"))
-
-  
 }
 ```
 
@@ -60,10 +55,8 @@ $  export MONGO_PWD="xxxx"
 $ terraform plan
 ```
 
-
-
-
 ## Certificate information :
+
 Specify certificate information either with a directory or directly with the content of the files for connecting to the Mongodb host via TLS.
 
 ```hcl
@@ -76,9 +69,9 @@ provider "mongodb" {
   ssl = true
   # -> specify either
   certificate = pathexpand("~/.mongodb/ca.pem")
-
   }
 ```
+
 ## Argument Reference
 
 In addition to [generic `provider`
@@ -93,7 +86,7 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
   provided, but it can also be sourced from the `MONGO_PORT`
   environment variable.
 
-* `certificate` - (Optional) Path to a directory with certificate files  for connecting to the Docker host via TLS. I. If the path is blank, the MONGODB_CERT will also be checked.
+* `certificate` - (Optional) Path to a directory with certificate files for connecting to the Docker host via TLS. I. If the path is blank, the MONGODB_CERT will also be checked.
 
 * `username ` - (Optional) Specifies a username with which to authenticate to the MongoDB database. It must be
   provided, but it can also be sourced from the `MONGO_USR`
@@ -109,3 +102,9 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
 * `timeout` - (Optional) `default = 10000 ` Specifies the number of milliseconds that a single operation run on the Client can take before returning a timeout error.
 * `connect_timeout` - (Optional) `default = 30000 ` Specifies the time in milliseconds to attempt a connection before timing out.
 * `server_selection_timeout` - (Optional) Specifies the time in milliseconds to wait to find an available, suitable server to execute an operation.
+* `replica_set` - (Optional) Specifies the name of the replica set to connect to.
+* `replica_set_hosts` - (Optional) Comma separated list of hosts for the replica set.
+* `read_preference` - (Optional) Specifies the default read preference for the client (excluding tags). See [read preference](https://www.mongodb.com/docs/manual/core/read-preference/#std-label-read-preference) for more information.
+* `max_pool_size` - (Optional) Specifies the maximum number of clients or connections the driver can create in its connection pool.
+* `max_connecting` - (Optional) Specifies the maximum number of connections a driver's connection pool may be establishing concurrently.
+  Optional) Specifies the maximum number of connections a driver's connection pool may be establishing concurrently.

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -133,7 +133,7 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 	arguments = addArgs(arguments, "maxPoolSize="+strconv.Itoa(c.MaxPoolSize))
 	arguments = addArgs(arguments, "maxConnecting="+strconv.Itoa(c.MaxConnecting))
 
-	var uri = ""
+	var uri string
 
 	if c.ReplicaSetHosts != "" {
 		arguments = addArgs(arguments, "readPreference="+c.ReadPreference)

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -25,6 +25,7 @@ type ClientConfig struct {
 	Ssl                    bool
 	InsecureSkipVerify     bool
 	ReplicaSet             string
+	ReplicaSetHosts        string
 	RetryWrites            bool
 	Certificate            string
 	Direct                 bool
@@ -32,6 +33,9 @@ type ClientConfig struct {
 	Timeout                int
 	ConnectTimeout         int
 	ServerSelectionTimeout int
+	ReadPreference         string
+	MaxPoolSize            int
+	MaxConnecting          int
 }
 type DbUser struct {
 	Name     string `json:"name"`
@@ -86,6 +90,11 @@ type SingleResultGetRole struct {
 	} `json:"roles"`
 }
 
+type MongoProviderMeta struct {
+	Config *ClientConfig
+	Client *mongo.Client
+}
+
 func addArgs(arguments string, newArg string) string {
 	if arguments != "" {
 		return arguments + "&" + newArg
@@ -111,7 +120,7 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 	}
 
 	if c.Direct {
-		arguments = addArgs(arguments, "connect="+"direct")
+		arguments = addArgs(arguments, "connect=direct")
 	}
 
 	arguments = addArgs(arguments, "timeoutMS="+strconv.Itoa(c.Timeout))
@@ -121,7 +130,17 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 		arguments = addArgs(arguments, "serverSelectionTimeoutMS="+strconv.Itoa(c.ServerSelectionTimeout))
 	}
 
-	var uri = "mongodb://" + c.Host + ":" + c.Port + arguments
+	arguments = addArgs(arguments, "maxPoolSize="+strconv.Itoa(c.MaxPoolSize))
+	arguments = addArgs(arguments, "maxConnecting="+strconv.Itoa(c.MaxConnecting))
+
+	var uri = ""
+
+	if c.ReplicaSetHosts != "" {
+		arguments = addArgs(arguments, "readPreference="+c.ReadPreference)
+		uri = "mongodb://" + c.ReplicaSetHosts + arguments
+	} else {
+		uri = "mongodb://" + c.Host + ":" + c.Port + arguments
+	}
 
 	dialer, dialerErr := proxyDialer(c)
 

--- a/mongodb/resource_db_role.go
+++ b/mongodb/resource_db_role.go
@@ -80,11 +80,8 @@ func resourceDatabaseRole() *schema.Resource {
 }
 
 func resourceDatabaseRoleCreate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	var role = data.Get("name").(string)
 	var database = data.Get("database").(string)
 	var roleList []Role
@@ -114,11 +111,8 @@ func resourceDatabaseRoleCreate(ctx context.Context, data *schema.ResourceData, 
 }
 
 func resourceDatabaseRoleDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	var stateId = data.State().ID
 	roleName, database, err := resourceDatabaseRoleParseId(stateId)
 
@@ -137,11 +131,8 @@ func resourceDatabaseRoleDelete(ctx context.Context, data *schema.ResourceData, 
 }
 
 func resourceDatabaseRoleUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	var role = data.Get("name").(string)
 	var stateId = data.State().ID
 	_, database, err := resourceDatabaseRoleParseId(stateId)
@@ -179,11 +170,8 @@ func resourceDatabaseRoleUpdate(ctx context.Context, data *schema.ResourceData, 
 
 func resourceDatabaseRoleRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	stateID := data.State().ID
 	roleName, database, err := resourceDatabaseRoleParseId(stateID)
 	if err != nil {

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -56,11 +56,8 @@ func resourceDatabaseUser() *schema.Resource {
 }
 
 func resourceDatabaseUserDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	var stateId = data.State().ID
 	var database = data.Get("auth_database").(string)
 
@@ -84,11 +81,8 @@ func resourceDatabaseUserDelete(ctx context.Context, data *schema.ResourceData, 
 }
 
 func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	var stateId = data.State().ID
 	_, errEncoding := base64.StdEncoding.DecodeString(stateId)
 	if errEncoding != nil {
@@ -127,11 +121,8 @@ func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, 
 }
 
 func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	stateID := data.State().ID
 	username, database, err := resourceDatabaseUserParseId(stateID)
 	if err != nil {
@@ -169,11 +160,8 @@ func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i 
 }
 
 func resourceDatabaseUserCreate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	var config = i.(*ClientConfig)
-	client, connectionError := MongoClientInit(config)
-	if connectionError != nil {
-		return diag.Errorf("Error connecting to database : %s ", connectionError)
-	}
+	meta := i.(*MongoProviderMeta)
+	client := meta.Client
 	var database = data.Get("auth_database").(string)
 	var userName = data.Get("name").(string)
 	var userPassword = data.Get("password").(string)


### PR DESCRIPTION
We’ve been experiencing issues refreshing MongoDB resources when a significant number of users are managed across multiple collections.

This PR introduces the use of a **single MongoDB client instance**, reused in both `resource_db_role.go` and `resource_db_user.go`, which should significantly improve performance and reliability.

Additionally, several replica set–related configuration options have been added:

- `replica_set_hosts` – *(Optional)* Comma-separated list of hosts for the replica set. Use this to specify the hostname(s) of the `mongod` instances as listed in the replica set configuration, in addition to the `host:port` option.
- `read_preference` – *(Optional)* Specifies the default read preference for the client (excluding tags). See the [MongoDB documentation on read preference](https://www.mongodb.com/docs/manual/core/read-preference/#std-label-read-preference) for more details.
- `max_pool_size` – *(Optional)* Defines the maximum number of connections the driver can create in its connection pool.
- `max_connecting` – *(Optional)* Sets the maximum number of connections the driver’s connection pool may be establishing concurrently.