### PR TITLE
Add support for passwordless auth methods

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -84,3 +84,20 @@ resource "mongodb_db_user" "user" {
   }
 
 }
+
+# This example creates a database user with authentication via AWS IAM user or role. `auth_database` must be "$external"
+# and `auth_mechanisms` must include ["MONGODB-AWS"] per documentation:
+# https://docs.aws.amazon.com/documentdb/latest/developerguide/iam-identity-auth.html#iam-identity-auth-get-started
+resource "mongodb_db_user" "passwordless_user" {
+  name = "arn:aws:iam::123456789123:role/iamrole" # Or use an IAM user, example: "arn:aws:iam::123456789123:user/iamuser"
+  auth_database = "$external"
+  auth_mechanisms = ["MONGODB-AWS"]
+  role {
+    role = "read"
+    db =   "readDB"
+  }
+  role {
+    role = "readWrite"
+    db =   "readWriteDB"
+  }
+}


### PR DESCRIPTION
Note, I raised this PR in the original repo (https://github.com/Kaginari/terraform-provider-mongodb/pull/49) however it seems like it might not be maintained much any longer so raised here as there were recent updates, thank you.

Add support for [IAM authentication to DocumentDB](https://docs.aws.amazon.com/documentdb/latest/developerguide/iam-identity-auth.html)

This PR is to address the issue https://github.com/Kaginari/terraform-provider-mongodb/issues/42 (original repo)

- Make database user `password` optional.
- Introduce `auth_mechanisms` to pass in authentication mechanisms for database user
- Updated documentation to show example database user creation with IAM auth for DocumentDB


Example `terraform apply`:
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # mongodb_db_user.this["test_user1"] will be created
  + resource "mongodb_db_user" "this" {
      + auth_database   = "$external"
      + auth_mechanisms = [
          + "MONGODB-AWS",
        ]
      + id              = (known after apply)
      + name            = "arn:aws:iam::123456789123:role/iamrole"

      + role {
          + db   = "readWriteDb"
          + role = "readWrite"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mongodb_db_user.this["test_user1"]: Creating...
mongodb_db_user.this["test_user1"]: Creation complete after 2s [id=JGV4dGVybmFsLmFybjphd3M6aWFtOjoxMjM0NTY3ODkxMjM6cm9sZS9pYW1yb2xl]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

`show users`:
```
> use $external
switched to db $external
$external> show users
[
  {
    _id: 'arn:aws:iam::123456789123:role/iamrole',
    user: 'arn:aws:iam::123456789123:role/iamrole',
    db: '$external',
    roles: [ { db: 'readWriteDb', role: 'readWrite' } ]
  }
]
```

