### PR TITLE
feat: Add support for cluster-level privileges to mongodb_db_role resource

### DIFF
--- a/docs/resources/database_role.md
+++ b/docs/resources/database_role.md
@@ -19,10 +19,32 @@ resource "mongodb_db_role" "example_role" {
     collection = ""
     actions = ["listCollections", "createCollection","createIndex", "dropIndex", "insert", "remove", "renameCollectionSameDB", "update"]
   }
-
-
 }
 ```
+
+## Example Usage with cluster-level privileges
+
+Use `cluster = true` instead of `db`/`collection` to grant actions that apply to the cluster as a whole (e.g. replica set inspection, server diagnostics).
+
+```hcl
+resource "mongodb_db_role" "ops_role" {
+  name     = "opsMonitoring"
+  database = "admin"
+
+  # Replica set status & config (read-only)
+  privilege {
+    cluster = true
+    actions = ["replSetGetStatus", "replSetGetConfig"]
+  }
+
+  # Server diagnostics
+  privilege {
+    cluster = true
+    actions = ["serverStatus", "connPoolStats"]
+  }
+}
+```
+
 ## Example Usage with inherited roles
 
 ```hcl
@@ -63,11 +85,12 @@ resource "mongodb_db_role" "role_2" {
 ### Privilege
 Each object in the privilege array represents an individual privilege action granted by the role. It is not required.
 
-* `actions` - (Required) Array of the privilege action. For a complete list of actions available , see [Custom Role Actions](https://docs.mongodb.com/manual/reference/privilege-actions/)
+* `actions` - (Required) Array of the privilege action. For a complete list of actions available, see [Custom Role Actions](https://docs.mongodb.com/manual/reference/privilege-actions/).
 -> **Note**: The privilege actions available to the Custom Roles API resource represent a subset of the privilege actions available in the Atlas Custom Roles UI.
-* `db`	Database on which the action is granted.
-* `collection` - (Optional) Collection on which the action is granted. 
--> **Note**: If collection value is an empty string, the actions are granted on all collections within the database specified in the privilege.db field.
+* `db` - (Optional) Database on which the action is granted. Mutually exclusive with `cluster`.
+* `collection` - (Optional) Collection on which the action is granted. Mutually exclusive with `cluster`.
+-> **Note**: If `collection` is an empty string, the actions are granted on all collections within the database specified in `db`.
+* `cluster` - (Optional, default `false`) When `true`, the privilege applies to the cluster as a whole rather than a specific database or collection. Use this for actions such as `replSetGetStatus`, `replSetGetConfig`, `serverStatus`, and other cluster-level operations. When `cluster = true`, `db` and `collection` must not be set.
              
 ### Inherited Roles
 Each object in the inheritedRoles array represents a key-value pair indicating the inherited role and the database on which the role is granted. It is an optional field.
@@ -83,7 +106,7 @@ Each object in the inheritedRoles array represents a key-value pair indicating t
 
 ## Import
 
-Mongodb users can be imported using the hex encoded id, e.g. for a user named `user_test` and his database id `test_db` :
+Mongodb roles can be imported using the hex encoded id, e.g. for a role named `role_test` and its database id `test_db` :
 
 ```sh
 $ printf '%s' "test_db.role_test"  | base64

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -62,6 +62,17 @@ resource "mongodb_db_role" "role4" {
   name = "new_role4"
 }
 
+resource "mongodb_db_role" "cluster_role" {
+  database = "admin"
+  name     = "opsMonitoring"
+
+  # Replica set status & config (read-only cluster-level privileges)
+  privilege {
+    cluster = true
+    actions = ["replSetGetStatus", "replSetGetConfig"]
+  }
+}
+
 resource "mongodb_db_user" "user" {
   auth_database = "example"
   name = "monta"

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -54,6 +54,7 @@ func (role Role) String() string {
 type PrivilegeDto struct {
 	Db         string   `json:"db"`
 	Collection string   `json:"collection"`
+	Cluster    bool     `json:"cluster"`
 	Actions    []string `json:"actions"`
 }
 
@@ -84,6 +85,7 @@ type SingleResultGetRole struct {
 			Resource struct {
 				Db         string `json:"db"`
 				Collection string `json:"collection"`
+				Cluster    bool   `json:"cluster"`
 			} `json:"resource"`
 			Actions []string `json:"actions"`
 		} `json:"privileges"`

--- a/mongodb/helpers.go
+++ b/mongodb/helpers.go
@@ -36,17 +36,23 @@ func getActions(privilegeDto PrivilegeDto) []string {
 	return actions
 }
 
-func getPrivilegesFromDto(privilegeDtos []PrivilegeDto) []Privilege {
-	var privileges []Privilege
+func getPrivilegesFromDto(privilegeDtos []PrivilegeDto) []bson.D {
+	var privileges []bson.D
 
 	for _, element := range privilegeDtos {
-		var prv Privilege
-		prv.Resource = Resource{
-			Db:         element.Db,
-			Collection: element.Collection,
+		var resource bson.D
+		if element.Cluster {
+			resource = bson.D{{Key: "cluster", Value: true}}
+		} else {
+			resource = bson.D{
+				{Key: "db", Value: element.Db},
+				{Key: "collection", Value: element.Collection},
+			}
 		}
-		prv.Actions = getActions(element)
-		privileges = append(privileges, prv)
+		privileges = append(privileges, bson.D{
+			{Key: "resource", Value: resource},
+			{Key: "actions", Value: getActions(element)},
+		})
 	}
 
 	return privileges

--- a/mongodb/helpers_test.go
+++ b/mongodb/helpers_test.go
@@ -3,6 +3,8 @@ package mongodb
 import (
 	"reflect"
 	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 func TestGetActions(t *testing.T) {
@@ -20,14 +22,104 @@ func TestGetPrivilegesFromDto(t *testing.T) {
 	privilegesDto := PrivilegeDto{Db: "test", Collection: "test", Actions: []string{"remove", "update", "insert", "find"}}
 	privilegesDto2 := PrivilegeDto{Db: "test", Collection: "test2", Actions: []string{"remove", "update", "find"}}
 
-	expectedPrivilege1 := Privilege{Resource{Db: privilegesDto.Db, Collection: privilegesDto.Collection}, getActions(privilegesDto)}
-	expectedPrivilege2 := Privilege{Resource{Db: privilegesDto2.Db, Collection: privilegesDto2.Collection}, getActions(privilegesDto2)}
-
-	expectedPrivileges := []Privilege{expectedPrivilege1, expectedPrivilege2}
+	expectedPrivileges := []bson.D{
+		{
+			{Key: "resource", Value: bson.D{
+				{Key: "db", Value: "test"},
+				{Key: "collection", Value: "test"},
+			}},
+			{Key: "actions", Value: []string{"find", "insert", "remove", "update"}},
+		},
+		{
+			{Key: "resource", Value: bson.D{
+				{Key: "db", Value: "test"},
+				{Key: "collection", Value: "test2"},
+			}},
+			{Key: "actions", Value: []string{"find", "remove", "update"}},
+		},
+	}
 	privileges := getPrivilegesFromDto([]PrivilegeDto{privilegesDto, privilegesDto2})
 
 	if reflect.DeepEqual(expectedPrivileges, privileges) == false {
 		t.Errorf("Obtained privileges = %v; want %v", privileges, expectedPrivileges)
 	}
+}
 
+func TestValidateClusterPrivilege(t *testing.T) {
+	// The privilege `db` field has no Default in the schema, so Terraform sets it
+	// to "" when the user does not specify it. The boundary for the cluster check
+	// is therefore db != "": an empty string is the legitimate "not set" value and
+	// must not be rejected, while any explicit non-empty value (including "admin")
+	// is a misconfiguration because cluster = true has no database scope.
+	tests := []struct {
+		name    string
+		priv    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			// Normal cluster privilege — db and collection left unset (zero value "").
+			name:    "cluster only is valid",
+			priv:    map[string]interface{}{"cluster": true, "db": "", "collection": ""},
+			wantErr: false,
+		},
+		{
+			name:    "db and collection only is valid",
+			priv:    map[string]interface{}{"cluster": false, "db": "mydb", "collection": "mycol"},
+			wantErr: false,
+		},
+		{
+			name:    "neither cluster nor db/collection is valid",
+			priv:    map[string]interface{}{"cluster": false, "db": "", "collection": ""},
+			wantErr: false,
+		},
+		{
+			// Someone might set db = "admin" assuming that's where cluster roles live;
+			// this must be rejected because cluster = true has no db scope at all.
+			name:    "cluster true with db set to admin is invalid",
+			priv:    map[string]interface{}{"cluster": true, "db": "admin", "collection": ""},
+			wantErr: true,
+		},
+		{
+			name:    "cluster true with db set to other value is invalid",
+			priv:    map[string]interface{}{"cluster": true, "db": "mydb", "collection": ""},
+			wantErr: true,
+		},
+		{
+			name:    "cluster true with collection set is invalid",
+			priv:    map[string]interface{}{"cluster": true, "db": "", "collection": "mycol"},
+			wantErr: true,
+		},
+		{
+			name:    "cluster true with both db and collection set is invalid",
+			priv:    map[string]interface{}{"cluster": true, "db": "mydb", "collection": "mycol"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateClusterPrivilege(tt.priv)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateClusterPrivilege() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetPrivilegesFromDtoCluster(t *testing.T) {
+	clusterDto := PrivilegeDto{Cluster: true, Actions: []string{"replSetGetStatus", "replSetGetConfig"}}
+
+	expectedPrivileges := []bson.D{
+		{
+			{Key: "resource", Value: bson.D{
+				{Key: "cluster", Value: true},
+			}},
+			{Key: "actions", Value: []string{"replSetGetConfig", "replSetGetStatus"}},
+		},
+	}
+	privileges := getPrivilegesFromDto([]PrivilegeDto{clusterDto})
+
+	if reflect.DeepEqual(expectedPrivileges, privileges) == false {
+		t.Errorf("Obtained privileges = %v; want %v", privileges, expectedPrivileges)
+	}
 }

--- a/mongodb/resource_db_role.go
+++ b/mongodb/resource_db_role.go
@@ -13,6 +13,30 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+// validateClusterPrivilege enforces that cluster = true is mutually exclusive
+// with db and collection. It accepts the raw map that Terraform produces when
+// decoding a privilege block so that it can also be called directly in tests.
+func validateClusterPrivilege(priv map[string]interface{}) error {
+	cluster, _ := priv["cluster"].(bool)
+	db, _ := priv["db"].(string)
+	collection, _ := priv["collection"].(string)
+	if cluster && (db != "" || collection != "") {
+		return fmt.Errorf(
+			"privilege block: 'cluster = true' is mutually exclusive with 'db' and 'collection' — remove 'db' and 'collection' when using cluster-level privileges",
+		)
+	}
+	return nil
+}
+
+func privilegesMutualExclusivityDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	for _, p := range d.Get("privilege").(*schema.Set).List() {
+		if err := validateClusterPrivilege(p.(map[string]interface{})); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func resourceDatabaseRole() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDatabaseRoleCreate,
@@ -22,6 +46,7 @@ func resourceDatabaseRole() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: privilegesMutualExclusivityDiff,
 		Schema: map[string]*schema.Schema{
 			"database": {
 				Type:     schema.TypeString,
@@ -46,6 +71,11 @@ func resourceDatabaseRole() *schema.Resource {
 						"collection": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
+						"cluster": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 
 						"actions": {
@@ -204,6 +234,7 @@ func resourceDatabaseRoleRead(ctx context.Context, data *schema.ResourceData, i 
 		privileges[i] = map[string]interface{}{
 			"db":         s.Resource.Db,
 			"collection": s.Resource.Collection,
+			"cluster":    s.Resource.Cluster,
 			"actions":    actions,
 		}
 	}


### PR DESCRIPTION
This adds a `cluster` boolean attribute to the `privilege` block, enabling roles that require cluster-scoped actions (e.g. `replSetGetStatus`, `serverStatus`) to be managed via this resource.

**What changed**

- `Schema` - new optional `cluster` field (`default false`) on the `privilege` block. When `true`, the `privilege` is sent to MongoDB as `{ resource: { cluster: true } }` rather than `{  resource: { db: ..., collection: ... } }`.

- `Validation` - a `CustomizeDiff` hook rejects any `privilege` block where `cluster = true` is combined with a non-empty `db` or `collection`, catching the misconfiguration at plan time.

- `Read/refresh` - `SingleResultGetRole` now decodes the `cluster` field from MongoDB's rolesInfo response, so cluster privileges round-trip correctly through state.

**Usage**

```hcl
  resource "mongodb_db_role" "ops" {
    name     = "opsMonitoring"
    database = "admin"

    privilege {
      cluster = true
      actions = ["replSetGetStatus", "replSetGetConfig"]
    }
  }
```

`cluster = true` and `db`/`collection` are mutually exclusive - the provider will return an error at plan time if both are set.